### PR TITLE
Add explicit Foundation import statement

### DIFF
--- a/CourierProtobuf.podspec
+++ b/CourierProtobuf.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |c|
     c.name            = 'CourierProtobuf'
-    c.version         = '0.0.28'
+    c.version         = '0.0.30'
     c.summary         = "Gojek iOS Long Run Connection Open Source SDK"
     c.description     = "Publish and Subscribe data with bidirectional communication between client and server"
   

--- a/CourierProtobuf/ProtobufMessageAdapter.swift
+++ b/CourierProtobuf/ProtobufMessageAdapter.swift
@@ -1,5 +1,6 @@
 import CourierCore
 import CourierMQTT
+import Foundation
 import SwiftProtobuf
 
 public class ProtobufMessageAdapter: MessageAdapter {


### PR DESCRIPTION
This is needed when using this library in Bazel, incase of XBS/Cococapods Cocoapods adds UIKit/Foundation imports by default but Bazel won't add them hence adding it explicitly